### PR TITLE
Allow using node 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "author": "Francois-Guillaume Ribreau <npm@fgribreau.com> (http://fgribreau.com/)",
   "engines": {
-    "node": "6"
+    "node": ">6"
   },
   "bin": {
     "gron": "bin/gron.js",


### PR DESCRIPTION
Right now I can't install gron globally with yarn on node 7 as it checks the `engine` field in `package.json`. By allowing any node version greater than 6 that's fixed.

Given there's no native code in this module it's not likely that future node version will break it easily. (Especially not node 7)